### PR TITLE
Prevent rest emitter leak by updating restler

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,26 +3,25 @@ var stylus = require('stylus'),
     path = require('path'),
     pugstore = require('./store/pug'),
     view = require('./view')
-    app = express.createServer(),
-    port = process.env.PORT || 3000;
+    app = express(),
+    port = process.env.PORT || 3000,
+    errorHandler = require('errorhandler');
 
-app.configure(function () {
-  app.set('view engine', 'jade');
-});
+app.set('view engine', 'jade');
 
-app.configure('development', function () {
+if ('development' == app.get('env')) {
   app.use(stylus.middleware({ src: path.join(__dirname, 'public') }));
   app.use(express.static(path.join(__dirname, '/public')));
-  app.use(express.errorHandler({ dumpExceptions: true, showStack: true }));
-});
+  app.use(errorHandler({ dumpExceptions: true, showStack: true }));
+}
 
-app.configure('production', function () {
+if ('production' == app.get('env')) {
   var oneYear = 31557600000;
 
   app.use(stylus.middleware({ src: path.join(__dirname, 'public'), compress: true }));
   app.use(express.static(path.join(__dirname, '/public'), { maxAge: oneYear }));
   app.use(express.errorHandler());
-});
+}
 
 app.get('/',
   pugstore.find(1),

--- a/package.json
+++ b/package.json
@@ -9,9 +9,10 @@
     "node": "~v0.4.7"
   },
   "dependencies": {
-    "express": "~v2.5.6",
+    "errorhandler": "^1.3.2",
+    "express": "^4.11.1",
+    "jade": "^1.9.1",
     "restler": "~v0.2.5",
-    "jade": "~v0.20.0",
     "stylus": "~v0.22.5"
   },
   "devDependencies": {}

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "errorhandler": "^1.3.2",
     "express": "^4.11.1",
     "jade": "^1.9.1",
-    "restler": "~v0.2.5",
-    "stylus": "~v0.22.5"
+    "restler": "^3.2.2",
+    "stylus": "^0.49.3"
   },
   "devDependencies": {}
 }

--- a/store/pug.js
+++ b/store/pug.js
@@ -4,10 +4,10 @@ var rest = require('restler'),
 var pugme = {
   random: function (callback) {
     rest.get('http://pugme.herokuapp.com/random')
-        .on('success', function (data) { callback(null, data['pug']); })
-        .on('fail', function (data) { callback(data); })
-        .on('error', function (error) { callback(error); })
-        .on('abort', function () { callback('Request aborted.'); });
+        .once('success', function (data) { callback(null, data['pug']); })
+        .once('fail', function (data) { callback(data); })
+        .once('error', function (error) { callback(error); })
+        .once('abort', function () { callback('Request aborted.'); });
   }
 };
 

--- a/store/pug.js
+++ b/store/pug.js
@@ -4,10 +4,10 @@ var rest = require('restler'),
 var pugme = {
   random: function (callback) {
     rest.get('http://pugme.herokuapp.com/random')
-        .once('success', function (data) { callback(null, data['pug']); })
-        .once('fail', function (data) { callback(data); })
-        .once('error', function (error) { callback(error); })
-        .once('abort', function () { callback('Request aborted.'); });
+        .on('success', function (data) { callback(null, data['pug']); })
+        .on('fail', function (data) { callback(data); })
+        .on('error', function (error) { callback(error); })
+        .on('abort', function () { callback('Request aborted.'); });
   }
 };
 

--- a/views/layout.jade
+++ b/views/layout.jade
@@ -1,10 +1,10 @@
-!!! 5
+doctype html
 html(lang="en")
   head
     title pugbomb.me
     link(rel = "stylesheet", href="/css/base.css")
     meta(name = "viewport", content="width=device-width,initial-scale=1.0")
-    script
+    script.
       var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-28391470-1']);
       _gaq.push(['_trackPageview']);
@@ -15,4 +15,4 @@ html(lang="en")
          var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
       })();
   body
-    != body
+    block content

--- a/views/photo.jade
+++ b/views/photo.jade
@@ -1,14 +1,17 @@
-table.kennel
-  tr
-    td
-      .pug
-        img(src = pug.img, alt = 'here be pugs')
-        .sunglasses
-        a.cool-hat(href = '/', title = 'Moar pugs plz!')
-      .permapug
-        a(href = pug.url) Link to this pug
-        p.footer a dumb idea of
-          a(href = "http://twitter.com/adunkman") @adunkman
-          | &bull;
-          a(href = "https://github.com/adunkman/pugbomb") fork the source
-          | on github
+extends layout
+
+block content
+  table.kennel
+    tr
+      td
+        .pug
+          img(src = pug.img, alt = 'here be pugs')
+          .sunglasses
+          a.cool-hat(href = '/', title = 'Moar pugs plz!')
+        .permapug
+          a(href = pug.url) Link to this pug
+          p.footer a dumb idea of
+            a(href = "http://twitter.com/adunkman") @adunkman
+            | &bull;
+            a(href = "https://github.com/adunkman/pugbomb") fork the source
+            | on github


### PR DESCRIPTION
The callbacks were being called more than once due to a bug in rester, after further research it looks like this issue was fixed in restler: 3.1.0 (danwrong/restler#113)

This was previously causing the server to fall over (eventually) with node v10. "EventEmitter memory leak detected."
