### PR TITLE
Handle additional tumblr urls and protect against pugme returning HTML

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,11 @@ app.get('/',
   view.photo);
 
 app.get('/:server/:size/:key.:format',
-  pugstore.findByName('server', 'key', 'size', 'format'),
+  pugstore.findByName('server', '', 'key', 'size', 'format'),
+  view.photo);
+
+app.get('/:server/:directory/:size/:key.:format',
+  pugstore.findByName('server', 'directory', 'key', 'size', 'format'),
   view.photo);
 
 app.listen(port);

--- a/index.js
+++ b/index.js
@@ -3,26 +3,25 @@ var stylus = require('stylus'),
     path = require('path'),
     pugstore = require('./store/pug'),
     view = require('./view')
-    app = express.createServer(),
-    port = process.env.PORT || 3000;
+    app = express(),
+    port = process.env.PORT || 3000,
+    errorHandler = require('errorhandler');
 
-app.configure(function () {
-  app.set('view engine', 'jade');
-});
+app.set('view engine', 'jade');
 
-app.configure('development', function () {
+if ('development' == app.get('env')) {
   app.use(stylus.middleware({ src: path.join(__dirname, 'public') }));
   app.use(express.static(path.join(__dirname, '/public')));
-  app.use(express.errorHandler({ dumpExceptions: true, showStack: true }));
-});
+  app.use(errorHandler({ dumpExceptions: true, showStack: true }));
+}
 
-app.configure('production', function () {
+if ('production' == app.get('env')) {
   var oneYear = 31557600000;
 
   app.use(stylus.middleware({ src: path.join(__dirname, 'public'), compress: true }));
   app.use(express.static(path.join(__dirname, '/public'), { maxAge: oneYear }));
   app.use(express.errorHandler());
-});
+}
 
 app.get('/',
   pugstore.find(1),

--- a/models/pug.js
+++ b/models/pug.js
@@ -1,23 +1,26 @@
+var util = require('util');
+
 var Pug = function (remoteUrl) {
    this.img = remoteUrl;
    this.url = Pug.getLocalUrl(remoteUrl);
 };
 
-Pug.getRemoteUrl = function (server, key, size, format) {
-  return 'http://' + server + '.media.tumblr.com/' +
-    'tumblr_' + key + '_' + size + '.' + format;
+Pug.getRemoteUrl = function (server, directory, key, size, format) {
+  return util.format('http://%s.media.tumblr.com/%stumblr_%s_%d.%s', server, (directory ? directory + '/' : ''), key, size, format);
 };
 
 Pug.getLocalUrl = function (remoteUrl) {
-  var parsed = remoteUrl.match(/http:\/\/(\d+).media.tumblr.com\/tumblr_([^_]+)_(\d+).(\w+)/);
-  if (!parsed || parsed.length != 5) throw "Unexpected URL format.";
+  var parsed = remoteUrl.match(/http:\/\/(\d+).media.tumblr.com\/(\w*\/{0,1})tumblr_([^_]+)_(\d+).(\w+)/);
+  
+  if (!parsed || parsed.length != 6) throw "Unexpected URL format.";
 
   var server = parsed[1],
-      key = parsed[2],
-      size = parsed[3],
-      format = parsed[4];
+      directory = parsed[2],
+      key = parsed[3],
+      size = parsed[4],
+      format = parsed[5];
 
-  return '/' + server + '/' + size + '/' + key + '.' + format;
+  return util.format('%s/%s%s/%s/%s', server, (directory ? directory + '/' : ''), size, key, format);
 };
 
 module.exports = Pug;

--- a/models/pug.js
+++ b/models/pug.js
@@ -20,7 +20,7 @@ Pug.getLocalUrl = function (remoteUrl) {
       size = parsed[4],
       format = parsed[5];
 
-  return util.format('%s/%s%s/%s/%s', server, (directory ? directory + '/' : ''), size, key, format);
+  return util.format('/%s/%s%s/%s.%s', server, (directory ? directory + '/' : ''), size, key, format);
 };
 
 module.exports = Pug;

--- a/package.json
+++ b/package.json
@@ -9,9 +9,10 @@
     "node": "~v0.4.7"
   },
   "dependencies": {
-    "express": "~v2.5.6",
+    "errorhandler": "^1.3.2",
+    "express": "^4.11.1",
+    "jade": "^1.9.1",
     "restler": "~v0.2.5",
-    "jade": "~v0.20.0",
     "stylus": "~v0.22.5"
   },
   "devDependencies": {}

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "errorhandler": "^1.3.2",
     "express": "^4.11.1",
     "jade": "^1.9.1",
-    "restler": "~v0.2.5",
-    "stylus": "~v0.22.5"
+    "restler": "^3.2.2",
+    "stylus": "^0.49.3"
   },
   "devDependencies": {}
 }

--- a/store/pug.js
+++ b/store/pug.js
@@ -16,9 +16,12 @@ module.exports = {
     return function (request, response, next) {
       pugme.random(function (error, data) {
         if (error) next(error);
-
+        
+        var matchFirstURL = data.match(/http:[^"]+/),
+            firstURL = matchFirstURL && matchFirstURL[0];
+        
         response.data = {
-          pug: new Pug(data)
+          pug: new Pug(firstURL)
         };
 
         next();

--- a/store/pug.js
+++ b/store/pug.js
@@ -4,10 +4,10 @@ var rest = require('restler'),
 var pugme = {
   random: function (callback) {
     rest.get('http://pugme.herokuapp.com/random')
-        .on('success', function (data) { callback(null, data['pug']); })
-        .on('fail', function (data) { callback(data); })
-        .on('error', function (error) { callback(error); })
-        .on('abort', function () { callback('Request aborted.'); });
+        .once('success', function (data) { callback(null, data['pug']); })
+        .once('fail', function (data) { callback(data); })
+        .once('error', function (error) { callback(error); })
+        .once('abort', function () { callback('Request aborted.'); });
   }
 };
 

--- a/store/pug.js
+++ b/store/pug.js
@@ -29,9 +29,9 @@ module.exports = {
     };
   },
 
-  findByName: function (server, key, size, format) {
+  findByName: function (server, directory, key, size, format) {
     return function (request, response, next) {
-      var data = Pug.getRemoteUrl(request.params[server], request.params[key],
+      var data = Pug.getRemoteUrl(request.params[server], request.params[directory], request.params[key],
         request.params[size], request.params[format]);
 
       response.data = {

--- a/store/pug.js
+++ b/store/pug.js
@@ -4,10 +4,10 @@ var rest = require('restler'),
 var pugme = {
   random: function (callback) {
     rest.get('http://pugme.herokuapp.com/random')
-        .once('success', function (data) { callback(null, data['pug']); })
-        .once('fail', function (data) { callback(data); })
-        .once('error', function (error) { callback(error); })
-        .once('abort', function () { callback('Request aborted.'); });
+        .on('success', function (data) { callback(null, data['pug']); })
+        .on('fail', function (data) { callback(data); })
+        .on('error', function (error) { callback(error); })
+        .on('abort', function () { callback('Request aborted.'); });
   }
 };
 

--- a/views/layout.jade
+++ b/views/layout.jade
@@ -1,10 +1,10 @@
-!!! 5
+doctype html
 html(lang="en")
   head
     title pugbomb.me
     link(rel = "stylesheet", href="/css/base.css")
     meta(name = "viewport", content="width=device-width,initial-scale=1.0")
-    script
+    script.
       var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-28391470-1']);
       _gaq.push(['_trackPageview']);
@@ -15,4 +15,4 @@ html(lang="en")
          var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
       })();
   body
-    != body
+    block content

--- a/views/photo.jade
+++ b/views/photo.jade
@@ -1,14 +1,17 @@
-table.kennel
-  tr
-    td
-      .pug
-        img(src = pug.img, alt = 'here be pugs')
-        .sunglasses
-        a.cool-hat(href = '/', title = 'Moar pugs plz!')
-      .permapug
-        a(href = pug.url) Link to this pug
-        p.footer a dumb idea of
-          a(href = "http://twitter.com/adunkman") @adunkman
-          | &bull;
-          a(href = "https://github.com/adunkman/pugbomb") fork the source
-          | on github
+extends layout
+
+block content
+  table.kennel
+    tr
+      td
+        .pug
+          img(src = pug.img, alt = 'here be pugs')
+          .sunglasses
+          a.cool-hat(href = '/', title = 'Moar pugs plz!')
+        .permapug
+          a(href = pug.url) Link to this pug
+          p.footer a dumb idea of
+            a(href = "http://twitter.com/adunkman") @adunkman
+            | &bull;
+            a(href = "https://github.com/adunkman/pugbomb") fork the source
+            | on github


### PR DESCRIPTION
There appear to be two different formats now:
1. `http://30.media.tumblr.com/tumblr_lsx4nsg5Hj1qa25vco1_500.jpg`
2. `http://41.media.tumblr.com/95a84579fa297844891b3ab1a5c76c0a/tumblr_mooibbcKl51rylzllo1_500.jpg`
This change adds support for the optional directory before the image file.

Additionally the pugme service appears to occasionally return html rather than a url, e.g. 
`http://30.media.tumblr.com/tumblr_lsx4nsg5Hj1qa25vco1_500.jpg"/><br/><br/><img
src="http://28.media.tumblr.com/tumblr_lsx4nsg5Hj1qa25vco8_500.jpg`
The change grabs the first url only from the pugme input

Note: this PR includes my previous PR's as it was forked from that branch
